### PR TITLE
[1팀 박예선] [Add]: 재생컴포넌트 생성 후 ui위치 조정

### DIFF
--- a/src/components/record/PlayBtn.jsx
+++ b/src/components/record/PlayBtn.jsx
@@ -1,0 +1,36 @@
+import { useRef, useState } from 'react';
+import { IoIosPlay, IoMdPause } from 'react-icons/io';
+import styled from 'styled-components';
+
+const PlayBtn = ({ audioURL }) => {
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const audioElement = useRef(null);
+
+  const toggleAudio = () => {
+    if (audioURL) {
+      if (!isPlaying) {
+        setIsPlaying(true);
+        audioElement.current.play();
+      } else {
+        audioElement.current.pause();
+        audioElement.current.currentTime = 0;
+        setIsPlaying(false);
+      }
+    }
+  };
+
+  return (
+    <PlayBtnContainer>
+      <audio ref={audioElement} controls src={audioURL} onEnded={() => setIsPlaying(false)} onClick={toggleAudio}>
+        오디오 재생 x
+      </audio>
+      <span>{isPlaying ? '중지' : '재생'}</span>
+      <button onClick={toggleAudio}>{isPlaying ? <IoMdPause /> : <IoIosPlay />}</button>
+    </PlayBtnContainer>
+  );
+};
+
+const PlayBtnContainer = styled.div``;
+
+export default PlayBtn;

--- a/src/components/record/PlayBtn.jsx
+++ b/src/components/record/PlayBtn.jsx
@@ -23,12 +23,10 @@ const PlayBtn = ({ isPlaying, setIsPlaying, isSaving, audioURL }) => {
     audioURL && (
       <PlayBtnContainer>
         <StartButton onClick={toggleAudio}>
-          {!isSaving && <span className='playBtn'>{isPlaying ? '중지' : '재생'}</span>}
+          {!isSaving && <span className='playBtn'>{!isSaving && isPlaying ? '중지' : '재생'}</span>}
           {isSaving && <span className='playBtn'> 저장 중...</span>}
         </StartButton>
-        <audio ref={audioElement} src={audioURL} onEnded={() => setIsPlaying(false)} onClick={toggleAudio}>
-          오디오 재생 x
-        </audio>
+        <audio ref={audioElement} src={audioURL} onEnded={() => setIsPlaying(false)} onClick={toggleAudio} />
       </PlayBtnContainer>
     )
   );

--- a/src/components/record/PlayBtn.jsx
+++ b/src/components/record/PlayBtn.jsx
@@ -3,7 +3,7 @@ import { IoIosPlay, IoMdPause } from 'react-icons/io';
 import styled from 'styled-components';
 import { StartButton } from '../../pages/record/Record';
 
-const PlayBtn = ({ isPlaying, setIsPlaying, audioURL }) => {
+const PlayBtn = ({ isPlaying, setIsPlaying, isSaving, audioURL }) => {
   const audioElement = useRef(null);
 
   const toggleAudio = () => {
@@ -23,7 +23,8 @@ const PlayBtn = ({ isPlaying, setIsPlaying, audioURL }) => {
     audioURL && (
       <PlayBtnContainer>
         <StartButton onClick={toggleAudio}>
-          <span className='playBtn'>{isPlaying ? '중지' : '재생'}</span>
+          {!isSaving && <span className='playBtn'>{isPlaying ? '중지' : '재생'}</span>}
+          {isSaving && <span className='playBtn'> 저장 중...</span>}
         </StartButton>
         <audio ref={audioElement} src={audioURL} onEnded={() => setIsPlaying(false)} onClick={toggleAudio}>
           오디오 재생 x

--- a/src/components/record/PlayBtn.jsx
+++ b/src/components/record/PlayBtn.jsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { IoIosPlay, IoMdPause } from 'react-icons/io';
 import styled from 'styled-components';
+import { StartButton } from '../../pages/record/Record';
 
 const PlayBtn = ({ isPlaying, setIsPlaying, audioURL }) => {
   const audioElement = useRef(null);
@@ -19,16 +20,23 @@ const PlayBtn = ({ isPlaying, setIsPlaying, audioURL }) => {
   };
 
   return (
-    <PlayBtnContainer>
-      <audio ref={audioElement} src={audioURL} onEnded={() => setIsPlaying(false)} onClick={toggleAudio}>
-        오디오 재생 x
-      </audio>
-      <span>{isPlaying ? '중지' : '재생'}</span>
-      <button onClick={toggleAudio}>{isPlaying ? <IoMdPause /> : <IoIosPlay />}</button>
-    </PlayBtnContainer>
+    audioURL && (
+      <PlayBtnContainer>
+        <StartButton onClick={toggleAudio}>
+          <span className='playBtn'>{isPlaying ? '중지' : '재생'}</span>
+        </StartButton>
+        <audio ref={audioElement} src={audioURL} onEnded={() => setIsPlaying(false)} onClick={toggleAudio}>
+          오디오 재생 x
+        </audio>
+      </PlayBtnContainer>
+    )
   );
 };
 
-const PlayBtnContainer = styled.div``;
+const PlayBtnContainer = styled.div`
+  .playBtn {
+    line-height: 30px;
+  }
+`;
 
 export default PlayBtn;

--- a/src/components/record/PlayBtn.jsx
+++ b/src/components/record/PlayBtn.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { IoIosPlay, IoMdPause } from 'react-icons/io';
 import styled from 'styled-components';
 

--- a/src/pages/play/Play.jsx
+++ b/src/pages/play/Play.jsx
@@ -10,6 +10,4 @@ const Play = () => {
   return <audio src={audioURL} />;
 };
 
-const PlayContainer = styled.div``;
-
 export default Play;

--- a/src/pages/play/Play.jsx
+++ b/src/pages/play/Play.jsx
@@ -1,12 +1,6 @@
 import styled from 'styled-components';
 
-recordPlay = new MediaPlayer();
-
 const Play = () => {
-  //음성이 녹음된 후 재생컴포넌트 만들기
-  //재생 버튼 클릭 시 재생화면나오게
-  // navigator.mediaDevices.getUserMedia({ audio: true });
-
   return <PlayContainer>Play</PlayContainer>;
 };
 

--- a/src/pages/play/Play.jsx
+++ b/src/pages/play/Play.jsx
@@ -1,7 +1,15 @@
-import React from 'react';
+import styled from 'styled-components';
+
+recordPlay = new MediaPlayer();
 
 const Play = () => {
-  return <div>Play</div>;
+  //음성이 녹음된 후 재생컴포넌트 만들기
+  //재생 버튼 클릭 시 재생화면나오게
+  // navigator.mediaDevices.getUserMedia({ audio: true });
+
+  return <PlayContainer>Play</PlayContainer>;
 };
+
+const PlayContainer = styled.div``;
 
 export default Play;

--- a/src/pages/record/Record.jsx
+++ b/src/pages/record/Record.jsx
@@ -3,10 +3,10 @@ import { BsFillRecordFill, BsSquareFill } from 'react-icons/bs';
 import { ref, uploadBytes } from 'firebase/storage';
 import styled from 'styled-components';
 
-import PlayBtn from '../../components/record/PlayBtn';
-
 import storage from '../../firebase/storage';
+
 import RecordingMordal from '../../components/record/RecordingMordal';
+import PlayBtn from '../../components/record/PlayBtn';
 
 const Record = () => {
   const [isRecording, setIsRecording] = useState(false);
@@ -91,7 +91,7 @@ const Record = () => {
       </Wrapper>
       {isRecording && <RecordingMordal />}
       {isSaving && <p>저장중...</p>}
-      <div className='buttonContainer'>{!isRecording && <PlayBtn isPlaying={isPlaying} setIsPlaying={setIsPlaying} audioURL={audioURL} />}</div>
+      {!isRecording && <PlayBtn isPlaying={isPlaying} setIsPlaying={setIsPlaying} audioURL={audioURL} />}
     </>
   );
 };
@@ -101,10 +101,6 @@ const StyledRecord = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  /* 
-  div.buttonContainer {
-    display: flex;
-  } */
 
   input {
     width: 100%;

--- a/src/pages/record/Record.jsx
+++ b/src/pages/record/Record.jsx
@@ -1,14 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 import { BsFillRecordFill, BsSquareFill } from 'react-icons/bs';
 import styled from 'styled-components';
+import PlayBtn from '../../components/record/PlayBtn';
 
 const Record = ({ audioURL, setAudioURL }) => {
   const [isRecording, setIsRecording] = useState(false);
-  const [isPlaying, setIsPlaying] = useState(false);
 
   const mediaRecorderRef = useRef();
   const audioArray = useRef([]);
-  const audioElement = useRef(null);
 
   const [timeMaxValue, setTimeMaxValue] = useState(20);
   const [timer, setTimer] = useState(0);
@@ -56,19 +55,6 @@ const Record = ({ audioURL, setAudioURL }) => {
     }
   }, [timer]);
 
-  const toggleAudio = () => {
-    if (audioURL) {
-      if (!isPlaying) {
-        setIsPlaying(true);
-        audioElement.current.play();
-      } else {
-        audioElement.current.pause();
-        audioElement.current.currentTime = 0;
-        setIsPlaying(false);
-      }
-    }
-  };
-
   return (
     <StyledRecord>
       <p>최대 녹음 시간 {timeMaxValue}s</p>
@@ -81,13 +67,11 @@ const Record = ({ audioURL, setAudioURL }) => {
         defaultValue={20}
         disabled={isRecording}
       />
-      <audio ref={audioElement} src={audioURL} onEnded={() => setIsPlaying(false)} />
       <div className='buttonContainer'>
         <button onClick={toggleRecord}>{isRecording ? <BsSquareFill /> : <BsFillRecordFill />}</button>
-        <button onClick={toggleAudio}>재생</button>
       </div>
       <p>{isRecording ? '녹음멈춤' : '녹음시작'}</p>
-      <p>{isPlaying ? '멈춤' : '재생'}</p>
+      <PlayBtn audioURL={audioURL} />
     </StyledRecord>
   );
 };

--- a/src/pages/record/Record.jsx
+++ b/src/pages/record/Record.jsx
@@ -86,7 +86,7 @@ const Record = () => {
       </StyledRecord>
       <ButtonWrapper>
         <StartButton isRecording={isRecording} onClick={toggleRecord} disabled={isPlaying}>
-          {audioURL && !isSaving && <span>다시 녹음하기</span>}
+          {audioURL && !isSaving && <span>다시 녹음</span>}
           {isRecording ? <BsSquareFill size={30} /> : <BsFillRecordFill size={30} />}
         </StartButton>
         {!isRecording && !isSaving && <PlayBtn isPlaying={isPlaying} setIsPlaying={setIsPlaying} audioURL={audioURL} />}

--- a/src/pages/record/Record.jsx
+++ b/src/pages/record/Record.jsx
@@ -84,14 +84,15 @@ const Record = () => {
         <p>현재 녹음 시간 {timer}s</p>
         <input type='range' onChange={({ target: { value } }) => setTimeMaxValue(Number(value))} max={100} min={3} defaultValue={20} disabled={isRecording} />
       </StyledRecord>
-      <Wrapper>
+      <ButtonWrapper>
         <StartButton isRecording={isRecording} onClick={toggleRecord} disabled={isPlaying}>
+          {audioURL && !isSaving && <span>다시 녹음하기</span>}
           {isRecording ? <BsSquareFill size={30} /> : <BsFillRecordFill size={30} />}
         </StartButton>
-      </Wrapper>
+        {!isRecording && !isSaving && <PlayBtn isPlaying={isPlaying} setIsPlaying={setIsPlaying} audioURL={audioURL} />}
+        {isSaving && <div>저장중...</div>}
+      </ButtonWrapper>
       {isRecording && <RecordingMordal />}
-      {isSaving && <p>저장중...</p>}
-      {!isRecording && <PlayBtn isPlaying={isPlaying} setIsPlaying={setIsPlaying} audioURL={audioURL} />}
     </>
   );
 };
@@ -107,19 +108,19 @@ const StyledRecord = styled.div`
   }
 `;
 
-const Wrapper = styled.div`
+const ButtonWrapper = styled.div`
   position: relative;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  flex-direction: column;
+  margin: auto;
 `;
 
-const StartButton = styled.button`
-  margin-top: 20px;
+export const StartButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
   width: 50%;
+  margin: 20px auto 0px;
   padding: 10px 40px;
   border: none;
   border-radius: 10px;

--- a/src/pages/record/Record.jsx
+++ b/src/pages/record/Record.jsx
@@ -89,8 +89,7 @@ const Record = () => {
           {audioURL && !isSaving && <span>다시 녹음</span>}
           {isRecording ? <BsSquareFill size={30} /> : <BsFillRecordFill size={30} />}
         </StartButton>
-        {!isRecording && !isSaving && <PlayBtn isPlaying={isPlaying} setIsPlaying={setIsPlaying} audioURL={audioURL} />}
-        {isSaving && <div>저장중...</div>}
+        {!isRecording && <PlayBtn isPlaying={isPlaying} setIsPlaying={setIsPlaying} isSaving={isSaving} audioURL={audioURL} />}
       </ButtonWrapper>
       {isRecording && <RecordingMordal />}
     </>
@@ -112,6 +111,7 @@ const ButtonWrapper = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
+  /* justify-content: center; */
   margin: auto;
 `;
 


### PR DESCRIPTION
## **:: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)**

1. 재생컴포넌트 분리
  -play페이지로직이 너무 길어지는 걸 방지하기 위해 재생하는 부분은 컴포넌트로 분리했습니다.
  -광현님이 만드신 버튼 컴포넌트를 export해서 재사용했습니다.

2. 녹음 ui 넣어주신 것에 맞춰서 재생컴포넌트 위치 변경했습니다.

3. '저장 중... ' 텍스트 재생컴포넌트로 위치 이동했습니다.

4. 광현님이 설정하신 Wrapper->ButtonWrapper로 이름 수정 후 재생 컴포넌트도
   그 안에 위치시켰습니다


## **:: 기타 질문 및 특이 사항**

- 재생컴포넌트 ui디자인은 아직 작업 전이라 녹음 ui와 규격맞춰서 수정예정이고
   재생시간표시하는 기능 등 필수 기능 추가예정입니다.
- ui 구현하실 때 헷갈리실까봐 일단 위치 조정하고 컴포넌트 분리한 작업먼저 pr합니다
